### PR TITLE
Update horizontal-with-axis.js

### DIFF
--- a/storybook/stories/bar-chart/horizontal-with-axis.js
+++ b/storybook/stories/bar-chart/horizontal-with-axis.js
@@ -36,7 +36,7 @@ class HorizontaBarChartWithYAxis extends React.PureComponent {
                 <YAxis
                     data={data}
                     yAccessor={({ index }) => index}
-                    scale={scale.scaleBand}
+                    scale={scale.scalePow}
                     contentInset={{ top: 10, bottom: 10 }}
                     spacing={0.2}
                     formatLabel={(_, index) => data[ index ].label}


### PR DESCRIPTION
Replace `scaleBand` which doesn't support `ticks` method, with `scalePow`.
For example, doesn't really matter which exact scale function it is as far it supports `ticks`.

Might be worth adding check to library, so developers know what went wrong.

Fixes: https://github.com/JesperLekland/react-native-svg-charts/issues/392